### PR TITLE
Update to models.py to handle newest versions of pydantic

### DIFF
--- a/multidoc/parsing/models.py
+++ b/multidoc/parsing/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import List, Optional, Union
 from multidoc.parsing.io import yaml2dict
 
 
@@ -41,7 +41,8 @@ class FileBased(BaseModel):
 
 
     """
-
+   
+    
     @classmethod
     def parse_yaml(cls, path, **kwargs):
         """
@@ -83,8 +84,8 @@ class Parameter(BaseModel):
     Attributes
     ----------
     Parameter.name : str
-    Parameter.type : Optional[str]
-    Parameter.description : Optional[str]
+    Parameter.type : Optional[str] = None
+    Parameter.description : Optional[str] = None
 
     Examples
     --------
@@ -114,8 +115,8 @@ class Parameter(BaseModel):
 
     """
     name: str
-    type: Optional[str]
-    description: Optional[str]
+    type: Optional[str] = None
+    description: Optional[str] = None
 
 
 class Property(BaseModel):
@@ -123,13 +124,13 @@ class Property(BaseModel):
     Attributes
     ----------
     Property.name : str
-    Property.type : Optional[str]
-    Property.description : Optional[str]
+    Property.type : Optional[str] = None
+    Property.description : Optional[str] = None
     Property.readonly : bool = False
     """
     name: str
-    type: Optional[str]
-    description: Optional[str]
+    type: Optional[str] = None
+    description: Optional[str] = None
     readonly : bool = False
 
 
@@ -138,40 +139,40 @@ class Returns(BaseModel):
 
     Attributes
     ----------
-    Returns.name : Optional[str]
-    Returns.type : Optional[str]
-    Returns.description : str
+    Returns.name : Optional[str] = None
+    Returns.type : Optional[str] = None
+    Returns.description : Optional[str] = None
 
     """
 
-    name: Optional[str]
-    type: Optional[str]
-    description: Optional[str]
+    name: Optional[str] = None
+    type: Optional[str] = None
+    description: Optional[str] = None
 
 class AutoClassConfig(BaseModel):
     """
     See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoclass
     """
-    members: Optional[str]
-    undoc_members: Optional[str]
-    private_members: Optional[str]
-    special_members: Optional[str]
-    no_undoc_members: Optional[bool]
-    inherited_members: Optional[bool]
+    members: Optional[str] = None
+    undoc_members: Optional[str] = None
+    private_members: Optional[str] = None
+    special_members: Optional[str] = None
+    no_undoc_members: Optional[bool] = None
+    inherited_members: Optional[bool] = None
 
 class Yields(BaseModel):
     """Yields docstring ``pydantic.BaseModel`` data structure.
 
     Attributes
     ----------
-    Yields.name: Optional[str]
-    Yields.type: Optional[str]
-    Yields.description: Optional[str]
+    Yields.name: Optional[str] = None
+    Yields.type: Optional[str] = None
+    Yields.description: Optional[str] = None
 
     """
-    name: Optional[str]
-    type: Optional[str]
-    description: Optional[str]
+    name: Optional[str] = None
+    type: Optional[str] = None
+    description: Optional[str] = None
 
 
 class Raises(BaseModel):
@@ -180,13 +181,27 @@ class Raises(BaseModel):
     Attributes
     ----------
     Raises.name: str
-    Raises.type: Optional[str]
-    Raises.description: Optional[str]
+    Raises.type: Optional[str] = None
+    Raises.description: Optional[str] = None
 
     """
     name: str
-    type: Optional[str]
-    description: Optional[str]
+    type: Optional[str] = None
+    description: Optional[str] = None
+    
+class Warns(BaseModel):
+    """Warns docstring ``pydantic.BaseModel`` data structure.
+
+    Attributes
+    ----------
+    Warns.name: Optional[str] = None
+    Warns.type: Optional[str] = None
+    Warns.description: Optional[str] = None
+
+    """
+    name: Optional[str] = None
+    type: Optional[str] = None
+    description: Optional[str] = None
 
 
 class Function(BaseModel):
@@ -195,43 +210,43 @@ class Function(BaseModel):
     Attributes
     ----------
     Function.name : str
-    Function.short_summary : Optional[str]  # test
-    Function.deprecation_warning : Optional[str]
-    Function.extended_summary : Optional[str]
-    Function.parameters : Optional[List[Parameter]]
-    Function.returns : Optional[Returns] or Optional[List[Returns]]
-    Function.yields : Optional[List[Yields] or Yields]
-    Function.other_parameters : Optional[List[Parameter]]
-    Function.raises : Optional[List[Raises] or Raises]
-    Function.warns : Optional[List[Raises] or Raises]
-    Function.warnings : Optional[str]
-    Function.see_also : Optional[str]
-    Function.notes : Optional[str]
-    Function.references : Optional[str]
-    Function.examples : Optional[str]
+    Function.short_summary: Optional[str] = None  # test
+    Function.deprecation_warning : Optional[str]= None
+    Function.extended_summary : Optional[str]= None
+    Function.parameters : Optional[Union[List[Parameter], Parameter]] = None
+    Function.returns: Optional[Union[List[Returns], Returns]] = None
+    Function.yields: Optional[Union[List[Yields], Yields]] = None
+    Function.other_parameters: Optional[Union[List[Parameter], Parameter]] = None
+    Function.raises: Optional[Union[List[Raises], Raises]] = None
+    Function.warns : Optional[Union[List[Warns], Warns]] = None
+    Function.warnings : Optional[str]= None
+    Function.see_also : Optional[str]= None
+    Function.notes : Optional[str]= None
+    Function.references : Optional[str]= None
+    Function.examples : Optional[str]= None
 
     """
     name: str
-    short_summary: Optional[str]
-    deprecation_warning: Optional[str]
-    extended_summary: Optional[str]
-    parameters: Optional[List[Parameter]]
-    returns: Optional[Returns] or Optional[List[Returns]]
-    yields: Optional[List[Yields] or Yields]
-    other_parameters: Optional[List[Parameter]]
-    raises: Optional[List[Raises] or Raises]
-    warns: Optional[List[Raises] or Raises]
-    warnings: Optional[str]
-    see_also: Optional[str]
-    notes: Optional[str]
-    references: Optional[str]
-    examples: Optional[str]
+    short_summary: Optional[str] = None
+    deprecation_warning: Optional[str] = None
+    extended_summary: Optional[str] = None
+    parameters: Optional[Union[List[Parameter], Parameter]] = None
+    returns: Optional[Union[List[Returns], Returns]] = None
+    yields: Optional[Union[List[Yields], Yields]] = None    
+    other_parameters: Optional[Union[List[Parameter], Parameter]] = None
+    raises: Optional[Union[List[Raises], Raises]] = None
+    warns: Optional[Union[List[Warns], Warns]] = None
+    warnings: Optional[str] = None
+    see_also: Optional[str] = None
+    notes: Optional[str] = None
+    references: Optional[str] = None
+    examples: Optional[str] = None
 
 
 class EnumMember(BaseModel):
     name: str
-    description: Optional[str]
-    value: Optional[int]
+    description: Optional[str] = None
+    value: Optional[int] = None
 
 
 class Class(BaseModel):
@@ -240,49 +255,51 @@ class Class(BaseModel):
     Attributes
     ----------
     Class.name : str
-    Class.short_summary : Optional[str]  # test
-    Class.deprecation_warning : Optional[str]
-    Class.extended_summary : Optional[str]
-    Class.parameters : Optional[List[Parameter]]
-    Class.returns : Optional[Returns] or Optional[List[Returns]]
-    Class.yields : Optional[List[Yields] or Yields]
-    Class.other_parameters : Optional[List[Parameter]]
-    Class.raises : Optional[List[Raises] or Raises]
-    Class.warns : Optional[List[Raises] or Raises]
-    Class.warnings : Optional[str]
-    Class.see_also : Optional[str]
-    Class.notes : Optional[str]
-    Class.references : Optional[str]
-    Class.examples : Optional[str]
-    Class.methods : Optional[str]
+    Class.short_summary : Optional[str] = None  # test
+    Class.deprecation_warning : Optional[str] = None
+    Class.extended_summary : Optional[str] = None
+    Class.parameters : Optional[Union[List[Parameter], Parameter]] = None
+    Class.attributes : Optional[Union[List[Parameter], Parameter]] = None
+    Class.properties : Optional[List[Property]] = None 
+    Class.yields : Optional[Union[List[Yields], Yields]] = None
+    Class.other_parameters : Optional[Union[List[Parameter], Parameter]] = None
+    Class.raises : Optional[Union[List[Raises], Raises]] = None
+    Class.warns : Optional[Union[List[Warns], Warns]] = None
+    Class.warnings : Optional[str] = None
+    Class.see_also : Optional[str] = None
+    Class.notes : Optional[str] = None
+    Class.references : Optional[str] = None
+    Class.examples : Optional[str] = None
+    Class.methods : Optional[str] = None
+    Class.autoclass: Optional[AutoClassConfig] = None
 
     """
 
     name: str
-    short_summary: Optional[str]
-    deprecation_warning: Optional[str]
-    extended_summary: Optional[str]
-    parameters: Optional[List[Parameter]]
-    attributes: Optional[List[Parameter]]
-    properties: Optional[List[Property]]
-    yields: Optional[List[Yields] or Yields]
-    other_parameters: Optional[List[Parameter] or Parameter]
-    raises: Optional[List[Raises] or Raises]
-    warns: Optional[List[Raises] or Raises]
-    warnings: Optional[str]
-    see_also: Optional[str]
-    notes: Optional[str]
-    references: Optional[str]
-    examples: Optional[str]
-    methods: Optional[List[Function]]
-    autoclass: Optional[AutoClassConfig]
+    short_summary: Optional[str] = None
+    deprecation_warning: Optional[str] = None
+    extended_summary: Optional[str] = None
+    parameters: Optional[Union[List[Parameter], Parameter]] = None
+    attributes: Optional[Union[List[Parameter], Parameter]] = None
+    properties: Optional[List[Property]] = None 
+    yields: Optional[Union[List[Yields], Yields]] = None
+    other_parameters: Optional[Union[List[Parameter], Parameter]] = None
+    raises: Optional[Union[List[Raises], Raises]] = None
+    warns: Optional[Union[List[Warns], Warns]] = None
+    warnings: Optional[str] = None
+    see_also: Optional[str] = None
+    notes: Optional[str] = None
+    references: Optional[str] = None
+    examples: Optional[str] = None
+    methods: Optional[List[Function]] = None
+    autoclass: Optional[AutoClassConfig] = None
 
 
 class Enum(BaseModel):
     name: str
-    short_summary: Optional[str]
-    extended_summary: Optional[str]
-    members: Optional[List[EnumMember]]
+    short_summary: Optional[str] = None
+    extended_summary: Optional[str] = None
+    members: Optional[List[EnumMember]] = None
 
 
 class Constant(BaseModel):
@@ -291,17 +308,17 @@ class Constant(BaseModel):
     Attributes
     ----------
     Constant.summary: str
-    Constant.extended_summary: Optional[str]
-    Constant.see_also: Optional[str]
-    Constant.references: Optional[str]
-    Constant.examples: Optional[str]
+    Constant.extended_summary: Optional[str] = None
+    Constant.see_also: Optional[str] = None
+    Constant.references: Optional[str] = None
+    Constant.examples: Optional[str] = None
 
     """
     summary: str
-    extended_summary: Optional[str]
-    see_also: Optional[str]
-    references: Optional[str]
-    examples: Optional[str]
+    extended_summary: Optional[str] = None
+    see_also: Optional[str] = None
+    references: Optional[str] = None
+    examples: Optional[str] = None
 
 
 class Config(BaseModel):
@@ -309,12 +326,12 @@ class Config(BaseModel):
 
     Attributes
     ----------
-    Config.name: Optional[str]
-    Config.version: Optional[str]
+    Config.name: Optional[str] = None
+    Config.version: Optional[str] = None
 
     """
-    name: Optional[str]
-    version: Optional[str]
+    name: Optional[str] = None
+    version: Optional[str] = None
 
 
 class Module(FileBased):
@@ -322,34 +339,38 @@ class Module(FileBased):
 
     Attributes
     ----------
-    Module.config: Optional[Config]
-    Module.summary: Optional[str]
-    Module.extended_summary: Optional[str]
-    Module.routine_listings: Optional[str]
-    Module.see_also: Optional[str]
-    Module.notes: Optional[str]
-    Module.references: Optional[str]
-    Module.examples: Optional[str]
-    Module.classes: Optional[List[Class]]
-    Module.functions: Optional[List[Function]]
-    Module.constants: Optional[List[Constant]]
+    Module.config: Optional[Config] = None  
+    
+    Module.summary: Optional[str] = None
+    Module.extended_summary: Optional[str] = None
+    Module.routine_listings: Optional[str] = None
+    Module.see_also: Optional[str] = None
+    Module.notes: Optional[str] = None
+    Module.references: Optional[str] = None
+    Module.examples: Optional[str] = None
+    
+    Module.enums: Optional[List[Enum]] = None
+    Module.classes: Optional[List[Class]] = None
+    Module.functions: Optional[List[Function]] = None
+    Module.constants: Optional[List[Constant]] = None
 
     """
-    config: Optional[Config]
-
-    summary: Optional[str]
-    extended_summary: Optional[str]
-    routine_listings: Optional[str]
-    see_also: Optional[str]
-    notes: Optional[str]
-    references: Optional[str]
-    examples: Optional[str]
+    config: Optional[Config] = None
+    
+    summary: Optional[str] = None
+    extended_summary: Optional[str] = None
+    routine_listings: Optional[str] = None
+    see_also: Optional[str] = None
+    notes: Optional[str] = None
+    references: Optional[str] = None
+    examples: Optional[str] = None
+    
 
     # MODULE structure
-    enums: Optional[List[Enum]]
-    classes: Optional[List[Class]]
-    functions: Optional[List[Function]]
-    constants: Optional[List[Constant]]
+    enums: Optional[List[Enum]] = None
+    classes: Optional[List[Class]] = None
+    functions: Optional[List[Function]] = None
+    constants: Optional[List[Constant]] = None
 
 
 class Package(Module):
@@ -357,21 +378,21 @@ class Package(Module):
 
     Attributes
     ----------
-    Package.config: Optional[Config]
-    Package.summary: Optional[str]
-    Package.extended_summary: Optional[str]
-    Package.routine_listings: Optional[str]
-    Package.see_also: Optional[str]
-    Package.notes: Optional[str]
-    Package.references: Optional[str]
-    Package.examples: Optional[str]
-    Package.classes: Optional[List[Class]]
-    Package.functions: Optional[List[Function]]
-    Package.constants: Optional[List[Constant]]
-    Package.modules: Optional[List[str]]
+    Package.config: Optional[Config] = None
+    Package.summary: Optional[str] = None
+    Package.extended_summary: Optional[str] = None
+    Package.routine_listings: Optional[str] = None
+    Package.see_also: Optional[str] = None
+    Package.notes: Optional[str] = None
+    Package.references: Optional[str] = None
+    Package.examples: Optional[str] = None
+    Package.classes: Optional[List[Class]] = None
+    Package.functions: Optional[List[Function]] = None
+    Package.constants: Optional[List[Constant]] = None
+    Package.modules: Optional[List[str]] = None
 
     """
-    modules: Optional[List[str]]
+    modules: Optional[List[str]] = None
 
     # def __init__(self):
     #     super().__init__()


### PR DESCRIPTION
I updated the usage of Optional() in models.py so that the API successfully builds with the newest version of pydantic (>V2.0). I also tested this update with the older version (pydantic 1.10.9) and that works too. 

If this update is merged you can remove the pydantic version from the environment.yaml in the tudat-multidoc folder. 